### PR TITLE
Fix only MarkdownView leaves being closable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -152,8 +152,11 @@ export default class PinEnhancerPlugin extends Plugin {
 			id: "alt-close-tab",
 			name: "Close tab",
 			callback: () => {
+				// Note that .getMostRecentLeaf() only looks at the main
+				// workspace, not the sidebars. This means the hotkey cannot be
+				// used to close tabs in sidebars.
 				const leaf =
-					this.app.workspace.getActiveViewOfType(MarkdownView)?.leaf;
+					this.app.workspace.getMostRecentLeaf();
 
 				if (!leaf) return;
 


### PR DESCRIPTION
Currently, the "New tab" page cannot be closed using the `Pin Enhancer: Close tab` command, because it is not a MarkdownView page. This PR changes how the command selects the page to close.

Replace leaf selection for alt-close-tab from `.getActiveViewOfType(MarkdownView)?.leaf` to `.getMostRecentLeaf()` to allow closing non-markdown tabs, such as the "New tab" page.

Tested locally. This might address #1, but I haven't tested it myself for that use case.

### Additional Comments
This PR introduces one opinionated change in plugin behavior -- the plugin's **close tab command will no longer work to close leaves in sidebars**. This is because [getMostRecentLeaf()](https://docs.obsidian.md/Reference/TypeScript+API/Workspace/getMostRecentLeaf) only looks at the main workspace (rootSplit) by default. Then, if a user uses the command while a sidebar leaf is selected, we need to decide whether to close the workspace tab or not.

I chose to still close the workspace tab, because I personally find it uncommon to need to close tabs in the sidebar, so if I press the hotkey then I probably am wanting to close the workspace tab anyway.

If we want to check if the selected leaf is active, so that we can ignore it if not, we can use:
```js
const isActive = leaf?.containerEl.classList.contains("mod-active");
```

If not being able to close sidebar leaves is an issue, perhaps it is possible to first check the current active workspace then pass this to the function, or to try the deprecated [workspace.activeLeaf](https://docs.obsidian.md/Reference/TypeScript+API/Workspace/activeLeaf).